### PR TITLE
Fix empty /style.css for subpackage SSR modules

### DIFF
--- a/docs/CHECK_PLAN.md
+++ b/docs/CHECK_PLAN.md
@@ -1,4 +1,7 @@
-# PLAN — Fix empty `/style.css` for subpackage SSR modules
+# CHECK_PLAN — Fix empty `/style.css` for subpackage SSR modules
+
+> **Status:** code patches applied. Unit test green. Production browser
+> verification still pending (see _Verification_ below).
 
 ## Problem
 
@@ -54,13 +57,15 @@ The extra symptom (unused-import compile error) was masked by
 `exec.Cmd.Output()` discarding stderr; this PLAN's first patch already
 captures stderr into the wrapped error so future regressions surface.
 
-## Fix
+## Fix (applied)
+
+Two complementary patches landed:
+
+### 1. `extractSSRAssetsForModule` ensures `m` is in the extractor set
 
 The contract of `extractSSRAssetsForModule(m, rootDir, allModules, _)` is:
-"return the SSR assets for `m`." It must therefore guarantee that `m`
-appears in the module set passed to `invokeSSRExtractorOnce`.
-
-Patch `extractSSRAssetsForModule`:
+"return the SSR assets for `m`." It now guarantees that `m` appears in
+the module set passed to `invokeSSRExtractorOnce`.
 
 ```go
 func extractSSRAssetsForModule(m Module, rootDir string, allModules []Module, binCachePath string) (*SSRAssets, error) {
@@ -98,33 +103,59 @@ Behavioural notes:
   per-subpackage. That is the correct granularity (different subpackages
   may have different SSR outputs even when the parent module set is fixed).
 
-Also keep the stderr-capture fix in `invokeSSRExtractorOnce` so future
-`go run` failures are visible in `c.Logger`-routed errors instead of
-returning a bare `exit status 1`.
+### 2. `HasAnyFeature` gates imports in the generated `main.go`
 
-## Files to change
+`ssr_invoke.go` adds `ModuleAlias.HasAnyFeature()` and the template now
+emits `import` and call blocks **only** for modules whose `ssr.go`
+exposes at least one SSR function:
 
-- `ssr_extract.go`:
-  - `extractSSRAssetsForModule`: append `m` to the module set when missing
-    before computing hash and invoking the extractor.
-  - Add small helper `containsModule`.
-- `ssr_invoke.go`: keep stderr-into-error wrap (already applied).
-- `ssr_extract_subpackage_test.go`: stays as the regression test.
+```gotmpl
+{{if .HasAnyFeature}}{{.Alias}} "{{.Path}}"{{end}}
+```
+
+This eliminates the `imported and not used` compile failure that
+manifested when a parent module without `ssr.go` was the only entry in
+the module set. It is a defence-in-depth fix: the appended `m` from
+patch (1) is what makes the subpackage's CSS reach the output, while
+`HasAnyFeature` keeps the generated program compilable when the
+non-SSR-bearing parent is also present.
+
+### 3. Stderr capture in `invokeSSRExtractorOnce`
+
+`exec.Cmd.Stderr` is now redirected into a buffer and folded into the
+returned error, so future `go run` failures surface as
+`go run failed: exit status 1: <compiler output>` rather than a bare
+`exit status 1`. Without this, the original bug took longer to diagnose.
+
+## Files changed
+
+- [`ssr_extract.go`](../ssr_extract.go) — `containsModule` helper +
+  `modulesForExtract` append in `extractSSRAssetsForModule`.
+- [`ssr_invoke.go`](../ssr_invoke.go) — `HasAnyFeature()` method,
+  template gates imports and call sites on it, stderr capture in
+  `invokeSSRExtractorOnce`.
+- [`ssr_extract_subpackage_test.go`](../ssr_extract_subpackage_test.go) —
+  regression test, lives in `package assetmin` (internal) so it can
+  exercise `extractSSRAssetsForModule` directly.
 
 ## Verification
 
-1. `go test -run TestExtractSSRAssetsForModule_Subpackage -v .` — passes.
-2. `go test ./...` in `assetmin/` — full suite stays green.
-3. Restart tinywasm daemon, reload `layout/platformd/web` demo:
-   - `curl -s http://localhost:6060/style.css | wc -c` returns ≫ 0.
-   - `browser_evaluate_js` reports non-empty `getComputedStyle(.pd-root)`.
+| Step | Status |
+|---|---|
+| `go test -run TestExtractSSRAssetsForModule_Subpackage -v .` | ✅ PASS |
+| `go test ./...` across `assetmin/`, `assetmin/tests/`, `assetmin/benchmark/` | ✅ PASS (~8s) |
+| Restart tinywasm daemon, reload `layout/platformd/web` demo | ⏳ pending |
+| `curl -s http://localhost:6060/style.css \| wc -c` returns ≫ 0 | ⏳ pending |
+| `browser_evaluate_js` reports non-empty `getComputedStyle(.pd-root)` | ⏳ pending — also blocked on the platformd render bug (see [`layout/docs/PLAN.md`](../../layout/docs/PLAN.md)) |
 
 ## Out of scope
 
-- Fixing the rendering side-effect introduced by the recent `*Element` →
-  `Element` change in `layout/platformd` (root tag is missing because
-  `Render()` returns `&p.Element` with no tag set). That belongs in a
-  PLAN under `layout/platformd/docs/`, not here.
-- Auditing why `loadSSRModulesLocked` swallows extractor errors (`if err
-  == nil`). Surfacing those errors to the logger is a follow-up — out of
-  scope for this CSS-emptiness bug fix, but recommended.
+- The platformd `Render()` rendering bug (root `<` tag with no element
+  name). Has its own plan at [`layout/docs/PLAN.md`](../../layout/docs/PLAN.md).
+  That is a separate bug — even with this assetmin fix delivering CSS,
+  the platformd HTML is malformed without that other patch.
+- Auditing why `loadSSRModulesLocked` swallows extractor errors
+  (`if err == nil` discards every error returned by
+  `extractSSRAssetsForModule`). Surfacing those into `c.Logger` would
+  have shortened diagnosis from hours to seconds. Recommended follow-up,
+  but not required for this bug fix.

--- a/docs/img/badges.svg
+++ b/docs/img/badges.svg
@@ -51,7 +51,7 @@
               text-anchor="middle" font-family="sans-serif" font-size="11" fill="white">Coverage</text>
         <!-- Value text -->
         <text x="86" y="14" 
-              text-anchor="middle" font-family="sans-serif" font-size="11" fill="white">75.5%</text>
+              text-anchor="middle" font-family="sans-serif" font-size="11" fill="white">75.8%</text>
     </g>
     <!-- Badge: Race -->
     <g transform="translate(397, 0)">

--- a/ssr_extract.go
+++ b/ssr_extract.go
@@ -64,8 +64,15 @@ func ExtractSSRAssets(moduleDir string) (*SSRAssets, error) {
 // extractSSRAssetsForModule is the internal implementation that takes a resolved Module.
 // binCachePath is reserved for future optimization (Problem 7).
 func extractSSRAssetsForModule(m Module, rootDir string, allModules []Module, binCachePath string) (*SSRAssets, error) {
+	// Ensure m is in the extractor's module set, so the generated main.go
+	// imports it and the results map carries an entry for m.Path.
+	modulesForExtract := allModules
+	if !containsModule(allModules, m) {
+		modulesForExtract = append(append([]Module(nil), allModules...), m)
+	}
+
 	// Compute hash of all modules to check global cache
-	hashKey, err := computeModuleHashSet(allModules)
+	hashKey, err := computeModuleHashSet(modulesForExtract)
 	if err != nil {
 		return nil, fmt.Err("failed to compute module hash", err)
 	}
@@ -75,7 +82,7 @@ func extractSSRAssetsForModule(m Module, rootDir string, allModules []Module, bi
 	cachedResults, hasCached := ssrGlobalCache.get(hashKey)
 	if !hasCached {
 		// Do compile-and-invoke
-		results, err := invokeSSRExtractorOnce(rootDir, allModules)
+		results, err := invokeSSRExtractorOnce(rootDir, modulesForExtract)
 		if err != nil {
 			ssrExtractMu.Unlock()
 			return nil, err
@@ -121,6 +128,15 @@ func findProjectRoot(startDir string) (string, error) {
 		}
 		dir = parent
 	}
+}
+
+func containsModule(mods []Module, m Module) bool {
+	for _, x := range mods {
+		if x.Path == m.Path && x.Dir == m.Dir {
+			return true
+		}
+	}
+	return false
 }
 
 // discoverModules discovers all modules in the project using go list.

--- a/ssr_invoke.go
+++ b/ssr_invoke.go
@@ -33,6 +33,10 @@ type ModuleAlias struct {
 	HasIcons    bool
 }
 
+func (m ModuleAlias) HasAnyFeature() bool {
+	return m.HasInstance || m.HasRoot || m.HasRender || m.HasHTML || m.HasJS || m.HasIcons
+}
+
 // Global mutex for SSR extraction protection
 var ssrExtractMu sync.Mutex
 
@@ -78,7 +82,7 @@ import (
 	"encoding/json"
 	"os"
 	{{range .Modules}}
-	{{if .Path}}{{.Alias}} "{{.Path}}"{{end}}
+	{{if .HasAnyFeature}}{{.Alias}} "{{.Path}}"{{end}}
 	{{end}}
 )
 
@@ -93,7 +97,7 @@ type ssr struct {
 func main() {
 	all := make(map[string]ssr)
 	{{range .Modules}}
-	{{if .Path}}
+	{{if .HasAnyFeature}}
 	{
 		var s ssr
 		{{if .HasInstance}}

--- a/tests/ssr_invoke_test.go
+++ b/tests/ssr_invoke_test.go
@@ -48,10 +48,16 @@ func (t *T) RenderCSS() *Stylesheet { return nil }
 
 func TestGenerateExtractorMain(t *testing.T) {
 	tmpDir := t.TempDir()
+
+	// Create a module with some features to ensure it is imported
+	modDir := filepath.Join(tmpDir, "mod1")
+	os.MkdirAll(modDir, 0755)
+	os.WriteFile(filepath.Join(modDir, "ssr.go"), []byte("package mod1\nfunc RenderCSS() {}"), 0644)
+
 	outputFile := filepath.Join(tmpDir, "main.go")
 
 	modules := []assetmin.Module{
-		{Path: "example.com/mod1", Dir: ""},
+		{Path: "example.com/mod1", Dir: modDir},
 	}
 
 	err := assetmin.GenerateExtractorMain(outputFile, modules)


### PR DESCRIPTION
This change addresses an issue where SSR assets for subpackages (like `layout/platformd`) were not being extracted because they weren't present in the `go list` results. It ensures the target module is always part of the extraction set. Additionally, it improves the extractor generation by only importing modules that actually have SSR features, avoiding compilation failures due to unused imports. Stderr from `go run` is now captured and included in errors for easier debugging.

---
*PR created automatically by Jules for task [5616484887255299178](https://jules.google.com/task/5616484887255299178) started by @cdvelop*